### PR TITLE
Add Scope 3 Challenge to Carbon Footprint section

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ Frameworks (via EEIO or LCA Models or Hybrid Models) that are indirectly support
 - [OpenIO-Canada](https://github.com/CIRAIG/OpenIO-Canada) - Module to create symmetric Environmentally Extended Input-Output tables for Canada.
 - [emission budgets](https://github.com/floriandierickx/emission-budgets) - visualising country-specific carbon budgets
 - [GHG Country Sector](https://github.com/martindaniel4/ghg_country_sector) - Visualization of Greenhouse Gas emissions by Country and Sector 
-  
+- [Scope 3 Challenge](https://github.com/co3org/Scope3-Challenge) - A deep-dive knowledge base covering all 15 GHG Protocol Scope 3 categories, PCAF financed emissions methodology (Category 15), attribution mechanics, and the full regulatory disclosure landscape (CSRD, SEC, ISSB S2, SBTi). Includes empirical data from 1,391 company disclosures and critical analysis of the inset credit market mechanism for supply-chain decarbonisation financing.
+
 ## Biodiversity Finance
 
 - [riskmapjnr](https://github.com/ghislainv/riskmapjnr) - The riskmapjnr Python package can be used to obtain maps of the spatial risk of deforestation and forest degradation


### PR DESCRIPTION
## What this adds

[Scope 3 Challenge](https://github.com/co3org/Scope3-Challenge) — an open knowledge base on corporate Scope 3 GHG accounting, added to the **Carbon Footprint** section.

## Why it fits

The Carbon Footprint section currently focuses on EEIO and LCA software tools. This resource fills the adjacent gap: a rigorous conceptual and methodological foundation for corporate value-chain carbon accounting — the framework that practitioners using these tools need to understand to interpret results correctly.

## What the resource covers

- All 15 GHG Protocol Scope 3 categories with calculation methods ranked by accuracy
- PCAF financed emissions methodology (Category 15) — directly relevant to this list's climate finance audience
- Attribution mechanics, double-counting, and boundary ambiguity
- Full regulatory disclosure landscape: CSRD, SEC Climate Rule, ISSB S2, SBTi Corporate Net-Zero Standard
- Empirical data from 1,391 company disclosures (Carbon3 Emissions Registry, API-accessible)
- Critical analysis of the inset credit market mechanism as supply-chain decarbonisation financing infrastructure

The PCAF coverage in particular fills a gap not addressed by any other entry in the current list.